### PR TITLE
Fix edge case error where there is no correct translation

### DIFF
--- a/scripts/generic/multi-bleu-detok.perl
+++ b/scripts/generic/multi-bleu-detok.perl
@@ -62,7 +62,9 @@ sub add_to_ref {
     close(REF);
 }
 
-my(@CORRECT,@TOTAL,$length_translation,$length_reference);
+my @CORRECT = (0) x 5;
+my @TOTAL = (0) x 5;
+my($length_translation,$length_reference);
 my $s=0;
 while(<STDIN>) {
     chop;


### PR DESCRIPTION
When validating very early in the training, there is a good chance that the translation is completely wrong, that is with no correct translated words. 
In this case, the script `multi-bleu-detok.perl` that computes the BLEU score displays the following messages:

    Use of uninitialized value in division (/) at ../tools/moses-scripts/scripts/generic/multi-bleu-detok.perl line 148, <STDIN> line 1760.

The fix consists in initializing the arrays `TOTAL` and `CORRECT` to 0.